### PR TITLE
Update Video Filtering

### DIFF
--- a/content.js
+++ b/content.js
@@ -25,19 +25,45 @@ function parseViewCount(viewCountText) {
   return views;
 }
 
+function getViewsText(item) {
+  // Standard metadata
+  const viewCountText = [...item.querySelectorAll("yt-content-metadata-view-model span")]
+    .find(el => /views?/i.test(el.textContent));
+
+  if (viewCountText) {
+    return viewCountText.textContent.trim();
+  }
+
+  // End screen
+  const videowallSpan = item.querySelector(
+    ".ytp-modern-videowall-still-view-count-and-date-info"
+  );
+
+  if (videowallSpan) {
+    return videowallSpan.textContent.trim();
+  }
+
+  return "";
+}
+
 function filterVideos() {
-  const videoItems = document.querySelectorAll('yt-lockup-view-model, ytd-video-renderer, ytd-rich-item-renderer');
+  const videoItems = document.querySelectorAll(`
+    yt-lockup-view-model,
+    ytd-video-renderer,
+    ytd-rich-item-renderer,
+    a.ytp-modern-videowall-still
+  `);
 
   videoItems.forEach(item => {
     if (item.dataset.viewsProcessed) return;
     item.dataset.viewsProcessed = "true";
 
-    const viewCountText = [...item.querySelectorAll("yt-content-metadata-view-model span")]
-      .find(el => /views?/i.test(el.textContent))?.textContent || "";
+    const viewCountText = getViewsText(item);
+    if (!viewCountText) return;
 
     const viewCount = parseViewCount(viewCountText);
     if (viewCount < minViews) {
-      item.style.display = 'none';
+      item.remove();
     }
   });
 }

--- a/content.js
+++ b/content.js
@@ -15,36 +15,39 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 });
 
 function parseViewCount(viewCountText) {
-  if (!viewCountText) return 0;
-  
-  viewCountText = viewCountText.replace(/,/g, '').toLowerCase();
-  
-  if (viewCountText.includes('m')) {
-    return parseFloat(viewCountText) * 1000000;
-  } else if (viewCountText.includes('k')) {
-    return parseFloat(viewCountText) * 1000;
-  } else {
-    return parseInt(viewCountText) || 0;
-  }
+  const [, num, suffix] = viewCountText.match(/([\d,.]+)\s*([kKmM]?)/) || [];
+
+  let views = parseFloat((num || "0").replace(/,/g, ""));
+
+  if (/k/i.test(suffix)) views *= 1000;
+  if (/m/i.test(suffix)) views *= 1000000;
+
+  return views;
 }
 
 function filterVideos() {
-  const videoItems = document.querySelectorAll('ytd-video-renderer, ytd-rich-item-renderer');
-  
+  const videoItems = document.querySelectorAll('yt-lockup-view-model, ytd-video-renderer, ytd-rich-item-renderer');
+
   videoItems.forEach(item => {
-    const viewCountElement = item.querySelector('#metadata-line span:first-of-type');
-    if (viewCountElement) {
-      const viewCount = parseViewCount(viewCountElement.textContent);
-      
-      if (viewCount < minViews) {
-        item.style.display = 'none';
-      }
+    if (item.dataset.viewsProcessed) return;
+    item.dataset.viewsProcessed = "true";
+
+    const viewCountText = [...item.querySelectorAll("yt-content-metadata-view-model span")]
+      .find(el => /views?/i.test(el.textContent))?.textContent || "";
+
+    const viewCount = parseViewCount(viewCountText);
+    if (viewCount < minViews) {
+      item.style.display = 'none';
     }
   });
 }
 
-const observer = new MutationObserver(function(mutations) {
-  filterVideos();
+let timeout;
+const observer = new MutationObserver(() => {
+  clearTimeout(timeout);
+  timeout = setTimeout(() => {
+    filterVideos();
+  }, 200);
 });
 
 observer.observe(document.body, {


### PR DESCRIPTION
Youtube now primarily uses `yt-lockup-view-model` elements and `yt-content-metadata-view-model` instead of `#metadata-line` for metadata. This updates both, plus the exact text to float parsing, to work properly again. Plus debounce as the page loads.